### PR TITLE
Adds delivered_msgs attribute to TopicStatistics message type

### DIFF
--- a/rosgraph_msgs/msg/TopicStatistics.msg
+++ b/rosgraph_msgs/msg/TopicStatistics.msg
@@ -11,6 +11,8 @@ string node_sub
 time window_start
 time window_stop
 
+# number of messages delivered during the window
+int32 delivered_msgs
 # numbers of messages dropped during the window
 int32 dropped_msgs
 


### PR DESCRIPTION
It is useful to have a count of how many messages have been sent during the time period.  
