### PR TITLE
Add Trigger service

### DIFF
--- a/std_srvs/CMakeLists.txt
+++ b/std_srvs/CMakeLists.txt
@@ -4,7 +4,9 @@ project(std_srvs)
 find_package(catkin REQUIRED COMPONENTS message_generation)
 
 add_service_files(DIRECTORY srv
-  FILES Empty.srv)
+  FILES
+  Empty.srv
+  Trigger.srv)
 
 generate_messages()
 

--- a/std_srvs/package.xml
+++ b/std_srvs/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>std_srvs</name>
   <version>1.11.0</version>
-  <description>Common service definitions. Currently just the 'Empty' service.</description>
+  <description>Common service definitions. Currently just the 'Empty' and 'Trigger' services.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>BSD</license>
 

--- a/std_srvs/srv/Trigger.srv
+++ b/std_srvs/srv/Trigger.srv
@@ -1,0 +1,3 @@
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages


### PR DESCRIPTION
This service is of general purpose for triggering. Compared to the `Empty.srv` it adds the possibility to check with the response if triggering was successful or not.
