### PR TITLE
Add Bool Service

### DIFF
--- a/std_srvs/CMakeLists.txt
+++ b/std_srvs/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS message_generation)
 add_service_files(DIRECTORY srv
   FILES
   Empty.srv
+  Bool.srv
   Trigger.srv)
 
 generate_messages()

--- a/std_srvs/package.xml
+++ b/std_srvs/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>std_srvs</name>
   <version>1.11.1</version>
-  <description>Common service definitions. Currently just the 'Empty' and 'Trigger' services.</description>
+  <description>Common service definitions.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>BSD</license>
 

--- a/std_srvs/srv/Bool.srv
+++ b/std_srvs/srv/Bool.srv
@@ -1,0 +1,4 @@
+bool data # e.g. for hardware enabling / disabling
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages


### PR DESCRIPTION
I often use a service with an additional bool field in my projects, e.g. for motor enabling/disabling, for switching a notification LED or to turn on/off a laser pointer. Any chance that it might be added to the std_srvs package?
