### PR TITLE
Add toggle service tool

### DIFF
--- a/std_srvs/CMakeLists.txt
+++ b/std_srvs/CMakeLists.txt
@@ -3,6 +3,8 @@ project(std_srvs)
 
 find_package(catkin REQUIRED COMPONENTS message_generation)
 
+catkin_python_setup()
+
 add_service_files(DIRECTORY srv
   FILES
   Empty.srv

--- a/std_srvs/setup.py
+++ b/std_srvs/setup.py
@@ -1,0 +1,12 @@
+## ------------------------------------------------------------ ##
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD ! ##
+## ------------------------------------------------------------ ##
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['std_srvs'],
+    package_dir={'': 'src'})
+
+setup(**setup_args)

--- a/std_srvs/src/std_srvs/tools.py
+++ b/std_srvs/src/std_srvs/tools.py
@@ -1,0 +1,19 @@
+import rospy
+from std_srvs.srv import SetBool, SetBoolResponse
+from rospy.impl.tcpros_base import DEFAULT_BUFF_SIZE
+
+class ToggleService(rospy.Service):
+
+    def __init__(self, name, enable_handler, disable_handler,
+                 buff_size=DEFAULT_BUFF_SIZE, error_handler=None):
+        super(ToggleService, self).__init__(name, SetBool, self.toggle,
+                                            buff_size=buff_size, error_handler=error_handler)
+        self.enable_handler = enable_handler
+        self.disable_handler = disable_handler
+
+    def toggle(self, req):
+        if req.data:
+            success, message = self.enable_handler()
+        else:
+            success, message = self.disable_handler()
+        return SetBoolResponse(success=success, message=message)


### PR DESCRIPTION
I am often writing toggle services for hardware and other nodes. Ultimately, I find myself repeatedly creating a `ToggleService` (as in 2e936dcfc74c7eaec12d88a7dbf9c0ae20bb53d1) across several packages. Any chance to merge?